### PR TITLE
Remove error in comparison of distances

### DIFF
--- a/gridfinder/gridfinder.py
+++ b/gridfinder/gridfinder.py
@@ -197,6 +197,7 @@ def optimise(
                         dist_add *= 1
                     else:  # or if it's diagonal
                         dist_add *= sqrt(2)
+
                     next_dist = current_dist + dist_add
 
                     if visited[next_loc]:

--- a/gridfinder/gridfinder.py
+++ b/gridfinder/gridfinder.py
@@ -197,11 +197,10 @@ def optimise(
                         dist_add *= 1
                     else:  # or if it's diagonal
                         dist_add *= sqrt(2)
-
                     next_dist = current_dist + dist_add
 
                     if visited[next_loc]:
-                        if next_dist + 0.4 < dist[next_loc]:
+                        if next_dist < dist[next_loc]:
                             dist[next_loc] = next_dist
                             prev[next_loc] = current_loc
                             heappush(queue, [next_dist, next_loc])


### PR DESCRIPTION
### Problem

The current implementation of the algorithm does not compare distance to the neighbor through the current node and previous distance correctly, because it adds a 'magic number' of 0.4 before comparison. This does not adhere to the algorithm as described in Box 1 of the paper at https://www.nature.com/articles/s41597-019-0347-4, and has been tested to lead to a different outcome than expected. 

### Appendix
Line 13 & 14 of pseudocode from paper:
```
if location already visited and distance < previous distance:
   change distance for location
```